### PR TITLE
use registry-info package for autherization token acquisition

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 import getRegistryUrl from 'registry-url';
-import getAuthToken from 'registry-auth-token';
+import getRegistryInfo from 'registry-info';
 import npa from 'npm-package-arg';
 import got from 'got';
 import httpHttpsAgent from 'http-https-agent';
@@ -13,13 +13,9 @@ const getAgent = httpHttpsAgent({
 module.exports = (packageName, opts = {}) => {
   const {scope, escapedName} = npa(packageName);
   const {registry = getRegistryUrl(scope)} = opts;
-
-  const {token} = getAuthToken(registry) || {};
+  const {authorization} = getRegistryInfo(scope);
+  const headers = authorization ? {authorization} : {};
   const url = join(registry, escapedName);
-
-  const headers = token ? {
-    authorization: 'Bearer ' + token
-  } : {};
   const agent = getAgent(url);
 
   return got(url, {headers, json: true, agent})

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-npm-registry-package",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Get a npm registry package",
   "main": "dist/index.js",
   "bin": {
@@ -10,8 +10,8 @@
     "got": "^6.3.0",
     "http-https-agent": "^1.0.1",
     "npm-package-arg": "^4.2.0",
-    "registry-auth-token": "^3.0.1",
     "registry-url": "^3.1.0",
+    "registry-info": "^1.0.0",
     "url-join": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This change fixes an issue with npm5 where authentication headers use 'Basic' prefix instead of 'Bearer'. The logic was taken from `download-npm-package` which uses `registry-info` package to acquire aforementioned headers